### PR TITLE
Fix build error on Xcode SwiftUI previews

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,10 @@ let package = Package(
         .target(
             name: "UnifiedLogging",
             dependencies: [
-                .product(name: "Logging", package: "swift-log", condition: .when(platforms: [.android, .linux, .wasi, .windows]))]),
+                .product(
+                    name: "Logging",
+                    package: "swift-log"),
+            ]),
         .testTarget(
             name: "UnifiedLoggingTests",
             dependencies: ["UnifiedLogging"]),

--- a/Sources/UnifiedLogging/Logger+Logging.swift
+++ b/Sources/UnifiedLogging/Logger+Logging.swift
@@ -5,7 +5,7 @@
 //  Created by Jaehong Kang on 2022/05/01.
 //
 
-#if canImport(Logging)
+#if !canImport(os)
 import Foundation
 import Logging
 


### PR DESCRIPTION
Xcode 13.4 (13F17a) does not check target dependencies’ conditions when it builds SwiftUI previews, and result in build failure.